### PR TITLE
sklearn LogisticRegression deprecated argument

### DIFF
--- a/benchml/predictors/pred_sklearn.py
+++ b/benchml/predictors/pred_sklearn.py
@@ -395,7 +395,6 @@ class LogisticRegression(SklearnTransform):
         random_state=None,
         solver="lbfgs",
         max_iter=100,
-        multi_class="auto",
         verbose=0,
         warm_start=False,
         n_jobs=None,


### PR DESCRIPTION
`multi_class` is deprecated and will be removed soon as an argument to `linear_model.LogisticRegression`. See: https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegression.html